### PR TITLE
Add HTTP path /methods to obtain info about service's methods

### DIFF
--- a/misc/testService/testMethod.h
+++ b/misc/testService/testMethod.h
@@ -6,7 +6,8 @@ class TestMethodArgs {
 public:
 	int32_t a;
 	int32_t b;
-	NSSERIALIZER_PREPARE(a,b);
+	std::vector<std::string> descs;
+	NSSERIALIZER_PREPARE(a,b, descs);
 };
 
 class TestMethodResult {

--- a/ns-skeleton/include/NsRpcRequest.h
+++ b/ns-skeleton/include/NsRpcRequest.h
@@ -32,7 +32,7 @@ namespace nanoservices {
 
 	class NsRpcRequest {
 	public:
-		NSSERIALIZER_PREPARE (_method, _argsSerialized, _waitForResponse);
+		NSSERIALIZER_PREPARE_SYS (_method, _argsSerialized, _waitForResponse);
 
 		NsRpcRequest();
 

--- a/ns-skeleton/include/NsRpcResponse.h
+++ b/ns-skeleton/include/NsRpcResponse.h
@@ -32,7 +32,7 @@ namespace nanoservices {
 
 	class NsRpcResponse {
 	public:
-		NSSERIALIZER_PREPARE (_success, _result);
+		NSSERIALIZER_PREPARE_SYS (_success, _result);
 
 		NsRpcResponse();
 

--- a/ns-skeleton/include/NsRpcResponseError.h
+++ b/ns-skeleton/include/NsRpcResponseError.h
@@ -36,7 +36,7 @@ namespace nanoservices {
 
 	class NsRpcResponseError {
 	public:
-		NSSERIALIZER_PREPARE (_errorCode, _errorDescription, _optionalErrorParams);
+		NSSERIALIZER_PREPARE_SYS (_errorCode, _errorDescription, _optionalErrorParams);
 
 		NsRpcResponseError();
 

--- a/ns-skeleton/include/NsSerializer.h
+++ b/ns-skeleton/include/NsSerializer.h
@@ -29,6 +29,8 @@
 
 #include <memory>
 #include <sstream>
+#include <numeric>
+#include <regex>
 
 #include <cstdint>
 #include <cstring>
@@ -41,10 +43,68 @@
 
 namespace msgpack2 = msgpack::v2;
 
-#define NSSERIALIZER_PREPARE MSGPACK_DEFINE
+#define NSSERIALIZER_PREPARE_SYS MSGPACK_DEFINE
+#define NSSERIALIZER_PREPARE(...) std::vector<std::string> __names__ = nanoservices::ListTypeNames(__VA_ARGS__); \
+NSSERIALIZER_PREPARE_SYS(__VA_ARGS__)
 #define NSSERIALIZER_ADD_ENUM MSGPACK_ADD_ENUM
 
 namespace nanoservices {
+
+	template<class ...Ts> struct TypeList {};
+
+	template<class T> constexpr std::string helper() {
+		return __PRETTY_FUNCTION__;
+	};
+	
+	template<class T> constexpr std::string getTypeName() {
+		std::smatch sm;
+ 
+		std::regex re1(R"(\[with T = (.*);)");
+		auto search = helper<T>();
+		std::regex_search(search, sm, re1);
+		return sm.str(1);
+	};
+
+	template<typename ...Ts> constexpr std::vector<std::string> ListTypeNames(Ts... args) {
+		return {nanoservices::getTypeName<Ts>()...};
+	};
+
+	class NsTypeInfo {
+		std::string _name;
+		std::vector<std::string> _fields;
+	public:
+		NsTypeInfo(std::string name, std::vector<std::string> fields) {
+			_name = name;
+			_fields = fields;
+		};
+
+		inline std::string getName() {return _name;};
+		inline std::string getDefinition() {
+			std::string resultText = "// Definition of " + _name + "\n\nclass ";
+			resultText += _name;
+			resultText += "{\npublic:\n";
+			int i = 1;
+			std::vector<std::string> fnames;
+			for(auto fieldType: _fields) {
+				std::string fname = "_" + std::to_string(i++);
+				fnames.push_back(fname);
+				resultText += "\t" + fieldType + " " + fname + ";\n";
+			}
+			resultText += "\tNSSERIALIZER_PREPARE(" + std::accumulate(std::next(fnames.begin()), fnames.end(),
+                                    fnames[0], // start with first element
+                                    [](std::string a, std::string b) {
+				         return std::move(a) + ',' + std::move(b);
+				     }) + ");\n};";
+			return resultText;
+		};
+	};
+
+	using NsTypeInfoPtr = std::shared_ptr<NsTypeInfo>;
+
+	template<class T> constexpr NsTypeInfoPtr getFullTypeName() {
+		auto fnames = (T()).__names__;
+		return std::make_shared<NsTypeInfo>(getTypeName<T>(), fnames);
+	};
 
 	std::string hexdump(const char *data, uint32_t len);
 

--- a/ns-skeleton/include/NsSkelRpcReplier.h
+++ b/ns-skeleton/include/NsSkelRpcReplier.h
@@ -74,6 +74,10 @@ namespace nanoservices {
 
 		virtual std::shared_ptr<Result> processRequest(std::shared_ptr<Args> args) throw(NsException) = 0;
 
+		NsTypeInfoPtr getArgsType() {return _types.first; };
+
+		NsTypeInfoPtr getReturnType() {return _types.second; };
+
 	private:
 		NsSkelRpcReplier(const NsSkelRpcReplier &orig) = delete;
 
@@ -81,6 +85,7 @@ namespace nanoservices {
 
 		NsSerializer<Args> _argsSerializer;
 		NsSerializer<Result> _resultSerializer;
+		std::pair<NsTypeInfoPtr, NsTypeInfoPtr> _types = std::make_pair<NsTypeInfoPtr, NsTypeInfoPtr>(getFullTypeName<Args>(), getFullTypeName<Result>());; 
 	};
 }
 

--- a/ns-skeleton/include/NsSkelRpcReplierInterface.h
+++ b/ns-skeleton/include/NsSkelRpcReplierInterface.h
@@ -47,6 +47,10 @@ namespace nanoservices {
 
 		virtual std::shared_ptr<NsSerialized> processSerializedRequest(NsSerialized &args) throw(NsException) = 0;
 
+		virtual NsTypeInfoPtr getArgsType() = 0;
+
+		virtual NsTypeInfoPtr getReturnType() = 0;
+
 	private:
 		NsSkelRpcReplierInterface(const NsSkelRpcReplierInterface &orig) = delete;
 

--- a/ns-skeleton/src/NsSkelRpcHttpServer.cpp
+++ b/ns-skeleton/src/NsSkelRpcHttpServer.cpp
@@ -68,6 +68,18 @@ NsSkelRpcHttpServer::NsSkelRpcHttpServer() : NsSkelRpcServer() {
 			res.set_header("Access-Control-Allow-Origin", "*");
 		}
 	});
+	_serverptr->Get("/methods", [&](const Request& req, Response& res) {
+		auto methods_list = NsSkelRpcRegistry::instance()->methods();
+		string content;
+		for(auto method : *methods_list) {
+			auto replier = NsSkelRpcRegistry::instance()->getReplier(make_shared<string>(method));
+			content += replier->getReturnType()->getName() + " " + method + "(" + replier->getArgsType()->getName() +")\n";
+			content += "//Received from " + *(NsSkelRpcRegistry::instance()->getLocalService()->serviceName()) + "\n";
+			content += replier->getArgsType()->getDefinition() + "\n";
+			content += replier->getReturnType()->getDefinition() + "\n";
+		}
+		res.set_content(content, "text/plain");
+	});
 }
 
 NsSkelRpcHttpServer::~NsSkelRpcHttpServer() {


### PR DESCRIPTION
 On branch feature-add-http-answer-about-service-methods
	modified:   misc/testService/testMethod.h
	modified:   ns-skeleton/include/NsRpcRequest.h
	modified:   ns-skeleton/include/NsRpcResponse.h
	modified:   ns-skeleton/include/NsRpcResponseError.h
	modified:   ns-skeleton/include/NsSerializer.h
	modified:   ns-skeleton/include/NsSkelRpcReplier.h
	modified:   ns-skeleton/include/NsSkelRpcReplierInterface.h
	modified:   ns-skeleton/src/NsSkelRpcHttpServer.cpp